### PR TITLE
Option to Load Custom Mesh

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -3,6 +3,7 @@ import torch
 from PIL import Image
 from pathlib import Path
 import numpy as np
+import trimesh
 
 from .hy3dgen.shapegen import Hunyuan3DDiTFlowMatchingPipeline, FaceReducer, FloaterRemover, DegenerateFaceRemover
 
@@ -137,7 +138,29 @@ class DownloadAndLoadHy3DDelightModel:
         delight_pipe.enable_model_cpu_offload()
         
         return (delight_pipe,)
+
+class LoadCustomMesh:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "glb": ("STRING", {"default": "", "tooltip": "The glb path with mesh to load. Tested only for now with other hunyuan3d-2 glbs"}), 
+            }
+        }
+    RETURN_TYPES = ("HY3DMESH",)
+    RETURN_NAMES = ("mesh",)
+    OUTPUT_TOOLTIPS = ("The glb model with mesh to texturize.",)
     
+    FUNCTION = "main"
+    CATEGORY = "Hunyuan3DWrapper"
+    DESCRIPTION = "Encodes a text prompt using a CLIP model into an embedding that can be used to guide the diffusion model towards generating specific images."
+
+    def main(self, glb):
+        
+        mesh = trimesh.load(glb, force="mesh")
+        
+        return (mesh,)
+        
 class Hy3DDelightImage:
     @classmethod
     def INPUT_TYPES(s):

--- a/nodes.py
+++ b/nodes.py
@@ -555,7 +555,8 @@ NODE_CLASS_MAPPINGS = {
     "Hy3DRenderMultiView": Hy3DRenderMultiView,
     "Hy3DBakeFromMultiview": Hy3DBakeFromMultiview,
     "Hy3DTorchCompileSettings": Hy3DTorchCompileSettings,
-    "Hy3DPostprocessMesh": Hy3DPostprocessMesh
+    "Hy3DPostprocessMesh": Hy3DPostprocessMesh,
+    "LoadCustomMesh": LoadCustomMesh
     }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "Hy3DModelLoader": "Hy3DModelLoader",
@@ -567,5 +568,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "Hy3DRenderMultiView": "Hy3D Render MultiView",
     "Hy3DBakeFromMultiview": "Hy3D Bake From Multiview",
     "Hy3DTorchCompileSettings": "Hy3D Torch Compile Settings",
-    "Hy3DPostprocessMesh": "Hy3D Postprocess Mesh"
+    "Hy3DPostprocessMesh": "Hy3D Postprocess Mesh",
+    "LoadCustomMesh": "Load Custom Mesh"
     }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/552adbe5-434e-4465-8d53-bb413908a282)


Quick node to load custom meshes, tested for now with other Hunyuan3D-2 glbs. If one wants only to generate texture, and has a mesh made by him or another ai model now can skip the mesh generation/bake from multiview. Useful also for debug tests.
It uses trimesh: `mesh = trimesh.load(glb, force="mesh")` (trimesh quick-start [link](https://trimesh.org/#quick-start))