### PR TITLE
Support for compiling on AMD systems

### DIFF
--- a/hy3dgen/texgen/custom_rasterizer/setup.py
+++ b/hy3dgen/texgen/custom_rasterizer/setup.py
@@ -3,9 +3,12 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 import torch
 
 torch_version = torch.__version__.split('+')[0].replace('.', '')
-cuda_version = torch.version.cuda.replace('.', '')
+if torch.version.cuda is not None:
+    cuda_version = "cuda"+torch.version.cuda.replace('.', '')
+elif getattr(torch.version, 'hip', None) is not None:
+    cuda_version = "rocm" + torch.version.hip.replace('.','')
 
-version = f"0.1.0+torch{torch_version}.cuda{cuda_version}"
+version = f"0.1.0+torch{torch_version}.{cuda_version}"
 # build custom rasterizer
 # build with `python setup.py install`
 # nvcc is needed


### PR DESCRIPTION
A minor change to support compilation on AMD systems.

I also had to force compilation with clang
```bash
CC="clang" CXX="clang++" python setup.py install
#...
CC="clang" CXX="clang++" python setup.py build_ext --inplace
```
And I'm seeing (system) crashes when executing "Hy3D Sample Multiview" (which I do not believe utilizes any of the compiled code), but both these issues are likely specific to my system