### PR TITLE
import torch first to load dll correctly

### DIFF
--- a/hy3dgen/texgen/custom_rasterizer/custom_rasterizer/render.py
+++ b/hy3dgen/texgen/custom_rasterizer/custom_rasterizer/render.py
@@ -22,8 +22,8 @@
 # fine-tuning enabling code and other elements of the foregoing made publicly available
 # by Tencent in accordance with TENCENT HUNYUAN COMMUNITY LICENSE AGREEMENT.
 
-import custom_rasterizer_kernel
 import torch
+import custom_rasterizer_kernel
 
 
 def rasterize(pos, tri, resolution, clamp_depth=torch.zeros(0), use_depth_prior=0):


### PR DESCRIPTION
when custom_rasterizer_kernel is imported before torch under cu128/python 3.12, the following error will raise:

ImportError: DLL load failed while importing custom_rasterizer_kernel: 找不到指定的模块。 

simply swapping these two imports will solve this issue