### PR TITLE
improve mv output quality when right angle input provided

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1297,8 +1297,8 @@ class Hy3DGenerateMeshMultiView():
         view_dict = {
             'front': front,
             'left': left,
-            'right': right,
-            'back': back
+            'back': back,
+            'right': right
         }
 
         if scheduler == "FlowMatchEulerDiscreteScheduler":


### PR DESCRIPTION
re-order mv index to align with shapegen expectation

- Switch the order of 'right' and 'back' in Hy3DGenerateMeshMultiView's view_dict to match the order expected by Shapegen's conditioner.py:
```
  self.view2idx = {
      'front': 0,
      'left': 1,
      'back': 2,
      'right': 3
  }
```
- This improves the generated quality for those areas.
- No workflow update needed as the expected input order remains the same.
- No impact on mv generation with right image input disabled (which is the case in the provided mv example workflow)  

<img width="1024" height="1024" alt="before_after_mesh" src="https://github.com/user-attachments/assets/ef221876-2704-4669-856a-c52d0c082b31" />
<img width="1400" height="1800" alt="before_after_texture" src="https://github.com/user-attachments/assets/ec3707d4-1501-4c62-a2bb-1103a2da9f60" />
